### PR TITLE
Startup Hook - shift gateway init to starup.

### DIFF
--- a/incubator/blockchain-client-openliberty/templates/default/src/main/java/application/api/StartupListener.java
+++ b/incubator/blockchain-client-openliberty/templates/default/src/main/java/application/api/StartupListener.java
@@ -1,0 +1,34 @@
+package application.api;
+
+import java.util.logging.Logger;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+import org.hyperledger.fabric.gateway.Contract;
+import org.hyperledger.fabric.gateway.GatewayException;
+import org.hyperledger.fabric_ca.sdk.exception.IdentityException;
+
+import application.cm.ConnectionConfiguration;
+import application.cm.ConnectionManager;
+
+@WebListener
+public class StartupListener implements ServletContextListener {
+
+    private static final Logger LOGGER = Logger.getLogger(StartupListener.class.getName());
+
+    public void contextInitialized(ServletContextEvent sce) {
+        LOGGER.info("Application being initialized.");
+        String defaultIdentity = ConnectionConfiguration.getFabricDefaultIdentity();
+        LOGGER.info("Identity: " + defaultIdentity);
+        try {
+            Contract c = ConnectionManager.getContract(defaultIdentity);
+            LOGGER.info("Contract : " +  c.toString());
+        } catch (IdentityException e) {
+            LOGGER.severe(e.toString());
+        } catch (GatewayException e) {
+            LOGGER.severe(e.toString());
+        }
+    }
+}


### PR DESCRIPTION
This change shifts the gateway initialization to the application startup.
Otherwise on first request this time is incurred.

Fully tested - ensured the code is getting the event and the logging proves the code is being executed. 

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [x] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stacks-overview.md#stack-structure).

### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
